### PR TITLE
fixtures: add Yaddle to people

### DIFF
--- a/resources/fixtures/people.json
+++ b/resources/fixtures/people.json
@@ -1392,5 +1392,22 @@
     },
     "model": "resources.people",
     "pk": 83
+},
+{
+    "fields": {
+        "edited": "2022-07-09T00:00:00.000Z",
+        "name": "Yaddle",
+        "created": "2022-07-09T00:00:00.000Z",
+        "gender": "female",
+        "skin_color": "green",
+        "hair_color": "auburn",
+        "height": "61",
+        "eye_color": "green-gold",
+        "mass": "unknown",
+        "homeworld": 28,
+        "birth_year": "509BBY"
+    },
+    "model": "resources.people",
+    "pk": 84
 }
 ]


### PR DESCRIPTION
Based on data found in https://starwars.fandom.com/wiki/Yaddle

## Why am I doing this PR?
I want to run a workshop where we play with this API.
For the workshop, we will create an API that returns a boolean that tells if the given character is taller than Yoda or not.
However, I just found out that Yoda is the shortest character on the list :(
I did some research and I found Yaddle, which is shorter than him!
Merging this PR will enable me to have at least an example of a character returning `true` :)